### PR TITLE
typo in asr_library.ipynb

### DIFF
--- a/asr_library.ipynb
+++ b/asr_library.ipynb
@@ -176,7 +176,7 @@
         "\n",
         "1. Load train/dev dataset\n",
         "2. Create minibatches\n",
-        "3. Bulild neural networks\n",
+        "3. Build neural networks\n",
         "4. Update neural networks by iterating datasets\n",
         "\n",
         "Let's implement these procedures from scratch!\n",


### PR DESCRIPTION
Caught a typo in the notebook `asr_library.ipynb`. 