### PR TITLE
fix typo in asr_cli.ipynb

### DIFF
--- a/asr_cli.ipynb
+++ b/asr_cli.ipynb
@@ -94,7 +94,7 @@
     "0. Data download (if available)\n",
     "1. Kaldi-style data preparation \n",
     "2. Save python-friendly data (e.g., JSON, HDF5, etc)\n",
-    "3. Lanuage model training\n",
+    "3. Language model training\n",
     "4. ASR model training\n",
     "5. Decoding and evaluation\n"
    ]


### PR DESCRIPTION
I found a typo in asr_cli.ipynb.

lanuage -> lauguage

Thanks.