### PR TITLE
Fix dependency issues in ESPnet2-TTS Colab Notebook (SciPy, NLTK, PyOpenJTalk)

### DIFF
--- a/ESPnet2/Demo/TTS/tts_realtime_demo.ipynb
+++ b/ESPnet2/Demo/TTS/tts_realtime_demo.ipynb
@@ -1,3 +1,4 @@
+
 {
   "nbformat": 4,
   "nbformat_minor": 0,
@@ -56,7 +57,7 @@
       },
       "source": [
         "# NOTE: pip shows imcompatible errors due to preinstalled libraries but you do not need to care\n",
-        "!pip install -q espnet==202308 pypinyin==0.44.0 parallel_wavegan==0.5.4 gdown==4.4.0 espnet_model_zoo\n"
+        "!pip install -q espnet==202412 pypinyin==0.44.0 parallel_wavegan==0.5.4 gdown==4.4.0 espnet_model_zoo\n"
       ],
       "execution_count": null,
       "outputs": []
@@ -192,7 +193,13 @@
         "    # Only for VITS\n",
         "    noise_scale=0.333,\n",
         "    noise_scale_dur=0.333,\n",
-        ")"
+        ")\n",
+        "\n",
+        "if lang == \"English\":\n",
+        "  import nltk\n",
+        "  nltk.download('averaged_perceptron_tagger_eng')\n",
+        "elif lang == \"Japanese\":\n",
+        "  !pip install -q pyopenjtalk"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Fix ESPnet2-TTS Colab Notebook: Update dependencies & ensure correct synthesis setup  

This commit addresses three key issues in the ESPnet2-TTS realtime demonstration notebook:  

- **Fixed outdated SciPy import:** Updated the installation step to use the 202412 version of ESPnet2, resolving an outdated kaiser import issue.  
- **Ensured nltk dataset availability:** Added a condition in the "Model Setup" section to automatically download the required dataset before English synthesis.  
- **Resolved Japanese synthesis dependency issue:** Introduced an additional condition to ensure pyopenjtalk is installed before running Japanese synthesis.  

These fixes improve first-time usability by preventing common dependency errors in the notebook.  

**References:**  
Fixes #6061, #6062, #6063.